### PR TITLE
`--enable-libnut` is not necessary for FFmpeg

### DIFF
--- a/src/README
+++ b/src/README
@@ -18,8 +18,6 @@ make
 
 
 to play with ffmpeg:
-./configure --enable-libnut
-make
 ./ffplay file.nut
 
 


### PR DESCRIPTION
NUT plays on current FFmpeg by default (at least on Linux and macOS).